### PR TITLE
ensure callback is called async with "dezalgo" option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,6 @@ module.exports = function (func, cb) {
   }, Array.prototype.slice.call(arguments, 2) );
 
   if (!async) {
-    cb(answer);
+    setImmediate(cb.bind(null, answer));
   }
 };

--- a/test.js
+++ b/test.js
@@ -5,13 +5,16 @@ var runAsync = require('./index');
 
 describe('runAsync', function () {
   it('run synchronous method', function (done) {
+    var ranAsync = false;
     var aFunc = function () {
       return 'pass1';
     };
     runAsync(aFunc, function (val) {
+      assert(ranAsync);
       assert.equal(val, 'pass1');
       done();
     });
+    ranAsync = true;
   });
 
   it('run asynchronous method', function (done) {


### PR DESCRIPTION
Currently your callback will be called synchronously if the users callback returns synchronously. That has utility in some situations, but generally, it is better to have consistency as it easier to reason about your code.

See isaacs [Don't Release Zalgo](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony) post (if you haven't already).

This PR adds an alternate method `runAsync.dezalgo` that will defer completion of your callback if the users callback returns synchronously.