### PR TITLE
add convenience method for promisification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
+  - '4.1'
   - '0.10'

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ module.exports = function (func, cb) {
  * @returns {Function} with identical signature as runAsync, but without the `cb` argument.
  */
 module.exports.promisify = function(Promise) {
+  Promise = Promise || global.Promise;
   return function(func) {
     var args = Array.prototype.slice.call(arguments, 1);
     return new Promise(function (resolve, reject) {

--- a/index.js
+++ b/index.js
@@ -3,15 +3,7 @@
 var once = require('once');
 var isPromise = require('is-promise');
 
-/**
- * Run a function asynchronously or synchronously
- * @param   {Function} func  Function to run
- * @param   {Function} cb    Callback function passed the `func` returned value
- * @...rest {Mixed}    rest  Arguments to pass to `func`
- * @return  {Null}
- */
-
-module.exports = function (func, cb) {
+function runAsync (func, cb, args) {
   var async = false;
   cb = once(cb);
 
@@ -21,7 +13,7 @@ module.exports = function (func, cb) {
         async = true;
         return cb;
       }
-    }, Array.prototype.slice.call(arguments, 2) );
+    }, args );
 
     if (!async) {
       if (isPromise(answer)) {
@@ -32,5 +24,38 @@ module.exports = function (func, cb) {
     }
   } catch (e) {
     setImmediate(cb.bind(null, e));
+  }
+}
+
+/**
+ * Run a function asynchronously or synchronously
+ * @param   {Function} func  Function to run
+ * @param   {Function} cb    Callback function passed the `func` returned value
+ * @...rest {Mixed}    rest  Arguments to pass to `func`
+ * @return  {undefined}
+ */
+module.exports = function (func, cb) {
+  runAsync(func, cb, Array.prototype.slice.call(arguments, 2));
+};
+
+/**
+ * Convenience method for promisifying the API.
+ * @param Promise an es6 Promise constructor.
+ * @returns {Function} with identical signature as runAsync, but without the `cb` argument.
+ */
+module.exports.promisify = function(Promise) {
+  return function(func) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    return new Promise(function (resolve, reject) {
+      runAsync(func, cb, args);
+
+      function cb(err, result) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      }
+    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "bluebird": "^2.10.2",
-    "mocha": "^1.21.4"
+    "mocha": "^1.21.4",
+    "semver": "^5.0.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,8 +2,19 @@
 
 var assert = require('assert');
 var runAsync = require('./index');
-var Promise = require('bluebird');
-var runAsyncPromise = runAsync.promisify(Promise);
+var semver = require('semver');
+var Promise;
+var runAsyncPromise;
+
+if (semver.gte(process.version, '4.0.0')) {
+  console.log('using native promises');
+  Promise = global.Promise;
+  runAsyncPromise = runAsync.promisify();
+} else {
+  console.log('using bluebird promises');
+  Promise = require('bluebird');
+  runAsyncPromise = runAsync.promisify(Promise);
+}
 
 describe('runAsync', function () {
   it('run synchronous method', function (done) {

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var runAsync = require('./index');
 var Promise = require('bluebird');
+var runAsyncPromise = runAsync.promisify(Promise);
 
 describe('runAsync', function () {
   it('run synchronous method', function (done) {
@@ -97,6 +98,28 @@ describe('runAsync', function () {
     runAsync(rejects, function (err, val) {
       assert(err);
       assert.equal(err.message, 'broken promise');
+      done();
+    });
+  });
+
+  it('can be promisified', function (done) {
+    var sync = function () {
+      return 'sync';
+    };
+
+    runAsyncPromise(sync).then(function (result) {
+      assert.equal(result, 'sync');
+      done();
+    });
+  });
+
+  it('promisified can be rejected', function (done) {
+    var throwsSync = function () {
+      throw new Error('throws sync');
+    };
+
+    runAsyncPromise(throwsSync).catch(function (err) {
+      assert.equal(err.message, 'throws sync');
       done();
     });
   });

--- a/test.js
+++ b/test.js
@@ -123,4 +123,18 @@ describe('runAsync', function () {
       done();
     });
   });
+
+  it('promisified passes args', function(done) {
+    var checkArgs = function (a, b) {
+      var done = this.async();
+      assert.equal(a, 'a');
+      assert.equal(b, 'b');
+      setImmediate(done.bind(null, null, 'c'));
+    };
+
+    runAsyncPromise(checkArgs, 'a', 'b').then(function (result) {
+      assert.equal(result, 'c');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
I dunno about this. It adds more code than I thought it would.

implements as discussed in #6.

Also makes `PromiseConstructor` optional if a global implementation exists.


```js
// must pass Promise constructor if global.Promise === undefined
// optional otherwise 
var runAsync = require('run-async').promisify([Promise]);

runAsync(fn, [...args]).then(....);
```
