### PR TITLE
Alternate promisification using promise-shim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
+  - '4.1'
   - '0.10'

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ module.exports = function (func, cb) {
  * @returns {Function} with identical signature as runAsync, but without the `cb` argument.
  */
 module.exports.promisify = function(Promise) {
+  Promise = Promise || global.Promise;
   return function(func) {
     var args = Array.prototype.slice.call(arguments, 1);
     return new Promise(function (resolve, reject) {

--- a/index.js
+++ b/index.js
@@ -3,15 +3,7 @@
 var once = require('once');
 var isPromise = require('is-promise');
 
-/**
- * Run a function asynchronously or synchronously
- * @param   {Function} func  Function to run
- * @param   {Function} cb    Callback function passed the `func` returned value
- * @...rest {Mixed}    rest  Arguments to pass to `func`
- * @return  {Null}
- */
-
-module.exports = function (func, cb) {
+function runAsync (func, cb, args) {
   var async = false;
   cb = once(cb);
 
@@ -21,7 +13,7 @@ module.exports = function (func, cb) {
         async = true;
         return cb;
       }
-    }, Array.prototype.slice.call(arguments, 2) );
+    }, args );
 
     if (!async) {
       if (isPromise(answer)) {
@@ -32,5 +24,38 @@ module.exports = function (func, cb) {
     }
   } catch (e) {
     setImmediate(cb.bind(null, e));
+  }
+}
+
+/**
+ * Run a function asynchronously or synchronously
+ * @param   {Function} func  Function to run
+ * @param   {Function} cb    Callback function passed the `func` returned value
+ * @...rest {Mixed}    rest  Arguments to pass to `func`
+ * @return  {undefined}
+ */
+module.exports = function (func, cb) {
+  runAsync(func, cb, Array.prototype.slice.call(arguments, 2));
+};
+
+/**
+ * Convenience method for promisifying the API.
+ * @param Promise an es6 Promise constructor.
+ * @returns {Function} with identical signature as runAsync, but without the `cb` argument.
+ */
+module.exports.promisify = function(Promise) {
+  return function(func) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    return new Promise(function (resolve, reject) {
+      runAsync(func, cb, args);
+
+      function cb(err, result) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      }
+    });
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,9 +1,18 @@
 'use strict';
+module.exports = runAsync;
 
 var once = require('once');
 var isPromise = require('is-promise');
+var promiseShim = require('promise-shim');
 
-function runAsync (func, cb, args) {
+/**
+ * Run a function asynchronously or synchronously
+ * @param   {Function} func  Function to run
+ * @param   {Function} cb    Callback function passed the `func` returned value
+ * @...rest {Mixed}    rest  Arguments to pass to `func`
+ * @return  {undefined}
+ */
+function runAsync (cb, func) {
   var async = false;
   cb = once(cb);
 
@@ -13,7 +22,7 @@ function runAsync (func, cb, args) {
         async = true;
         return cb;
       }
-    }, args );
+    }, Array.prototype.slice.call(arguments, 2));
 
     if (!async) {
       if (isPromise(answer)) {
@@ -28,35 +37,10 @@ function runAsync (func, cb, args) {
 }
 
 /**
- * Run a function asynchronously or synchronously
- * @param   {Function} func  Function to run
- * @param   {Function} cb    Callback function passed the `func` returned value
- * @...rest {Mixed}    rest  Arguments to pass to `func`
- * @return  {undefined}
- */
-module.exports = function (func, cb) {
-  runAsync(func, cb, Array.prototype.slice.call(arguments, 2));
-};
-
-/**
  * Convenience method for promisifying the API.
  * @param Promise an es6 Promise constructor.
  * @returns {Function} with identical signature as runAsync, but without the `cb` argument.
  */
 module.exports.promisify = function(Promise) {
-  Promise = Promise || global.Promise;
-  return function(func) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    return new Promise(function (resolve, reject) {
-      runAsync(func, cb, args);
-
-      function cb(err, result) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(result);
-        }
-      }
-    });
-  }
+  return promiseShim(Promise).bind(null, runAsync);
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "bluebird": "^2.10.2",
-    "mocha": "^1.21.4"
+    "mocha": "^1.21.4",
+    "semver": "^5.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/SBoudrias/run-async",
   "dependencies": {
     "is-promise": "^2.1.0",
-    "once": "^1.3.0"
+    "once": "^1.3.0",
+    "promise-shim": "^0.1.1"
   },
   "devDependencies": {
     "bluebird": "^2.10.2",

--- a/test.js
+++ b/test.js
@@ -2,8 +2,19 @@
 
 var assert = require('assert');
 var runAsync = require('./index');
-var Promise = require('bluebird');
-var runAsyncPromise = runAsync.promisify(Promise);
+var semver = require('semver');
+var Promise;
+var runAsyncPromise;
+
+if (semver.gte(process.version, '4.0.0')) {
+  console.log('using native promises');
+  Promise = global.Promise;
+  runAsyncPromise = runAsync.promisify();
+} else {
+  console.log('using bluebird promises');
+  Promise = require('bluebird');
+  runAsyncPromise = runAsync.promisify(Promise);
+}
 
 describe('runAsync', function () {
   it('run synchronous method', function (done) {

--- a/test.js
+++ b/test.js
@@ -22,12 +22,12 @@ describe('runAsync', function () {
     var aFunc = function () {
       return 'pass1';
     };
-    runAsync(aFunc, function (err, val) {
+    runAsync(function (err, val) {
       assert.ifError(err);
       assert(ranAsync);
       assert.equal(val, 'pass1');
       done();
-    });
+    }, aFunc);
     ranAsync = true;
   });
 
@@ -37,11 +37,11 @@ describe('runAsync', function () {
       setImmediate(returns.bind(null, null, 'pass2'));
     };
 
-    runAsync(aFunc, function (err, val) {
+    runAsync(function (err, val) {
       assert.ifError(err);
       assert.equal(val, 'pass2');
       done();
-    });
+    }, aFunc);
   });
 
   it('pass arguments', function (done) {
@@ -50,10 +50,10 @@ describe('runAsync', function () {
       assert.equal(b, 'bar');
       return 'pass1';
     };
-    runAsync(aFunc, function (err, val) {
+    runAsync(function (err, val) {
       assert.ifError(err);
       done();
-    }, 1, 'bar');
+    }, aFunc, 1, 'bar');
   });
 
   it('allow only callback once', function (done) {
@@ -63,10 +63,10 @@ describe('runAsync', function () {
       returns();
     };
 
-    runAsync(aFunc, function (err, val) {
+    runAsync(function (err, val) {
       assert.ifError(err);
       done();
-    });
+    }, aFunc);
   });
 
   it('handles promises', function (done) {
@@ -78,11 +78,11 @@ describe('runAsync', function () {
       });
     };
 
-    runAsync(fn, function (err, val) {
+    runAsync(function (err, val) {
       assert.ifError(err);
       assert.equal('as promised!', val);
       done();
-    });
+    }, fn);
   });
 
   it('throwing synchronously passes error to callback', function (done) {
@@ -90,11 +90,11 @@ describe('runAsync', function () {
       throw new Error('sync error');
     };
 
-    runAsync(throws, function (err, val) {
+    runAsync(function (err, val) {
       assert(err);
       assert.equal(err.message, 'sync error');
       done();
-    });
+    }, throws);
   });
 
   it('rejecting a promise passes error to callback', function (done) {
@@ -106,11 +106,11 @@ describe('runAsync', function () {
       });
     };
 
-    runAsync(rejects, function (err, val) {
+    runAsync(function (err, val) {
       assert(err);
       assert.equal(err.message, 'broken promise');
       done();
-    });
+    }, rejects);
   });
 
   it('can be promisified', function (done) {

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var runAsync = require('./index');
 var Promise = require('bluebird');
+var runAsyncPromise = runAsync.promisify(Promise);
 
 describe('runAsync', function () {
   it('run synchronous method', function (done) {
@@ -97,6 +98,28 @@ describe('runAsync', function () {
     runAsync(rejects, function (err, val) {
       assert(err);
       assert.equal(err.message, 'broken promise');
+      done();
+    });
+  });
+
+  it('can be promisified', function (done) {
+    var sync = function () {
+      return 'sync';
+    };
+
+    runAsyncPromise(sync).then(function (result) {
+      assert.equal(result, 'sync');
+      done();
+    });
+  });
+
+  it('promisified can be rejected', function (done) {
+    var throwsSync = function () {
+      throw new Error('throws sync');
+    };
+
+    runAsyncPromise(throwsSync).catch(function (err) {
+      assert.equal(err.message, 'throws sync');
       done();
     });
   });

--- a/test.js
+++ b/test.js
@@ -123,4 +123,18 @@ describe('runAsync', function () {
       done();
     });
   });
+
+  it('promisified passes args', function(done) {
+    var checkArgs = function (a, b) {
+      var done = this.async();
+      assert.equal(a, 'a');
+      assert.equal(b, 'b');
+      setImmediate(done.bind(null, null, 'c'));
+    };
+
+    runAsyncPromise(checkArgs, 'a', 'b').then(function (result) {
+      assert.equal(result, 'c');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
If we move the callback to the first argument it gets easy to implement promisification using `promise-shim`.

So easy it might be better to not return promises and either:

 1. show the user how to promisify it themselves
 2. deploy a separate module that wraps this one and promisifies it.