### PR TITLE
bump promise-resolver, and simplify implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,10 @@
   "homepage": "https://github.com/SBoudrias/run-async",
   "dependencies": {
     "is-promise": "^2.1.0",
-    "once": "^1.3.0",
-    "promise-resolver": "^2.0.0"
+    "promise-resolver": "^3.0.0"
   },
   "devDependencies": {
-    "bluebird": "^2.10.2",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "pinkie": "^1.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ var assert = require('assert');
 var runAsync = require('./index');
 
 describe('runAsync', function () {
-  var Promise = require('bluebird');
+  var Promise = require('pinkie');
 
   it('run synchronous method', function (done) {
     var ranAsync = false;
@@ -134,6 +134,6 @@ describe('runAsync', function () {
 
     assert.throws(function () {
       runAsync(returns)();
-    }, /No Native Promise Implementation/);
+    }, /No Promise Implementation/);
   });
 });


### PR DESCRIPTION
I released promise-resolver@2.0.0 a bit prematurely, and have already cut 3.0.0. It now handles a number of corner cases we were handling manually:

 1. Ensure callbacks are only called once
 2. Require a promise implementation if no callback is provided
 3. Ensure callbacks are called async

And a few we were missing:

 1. Look for `bluebird` and fallback to native promises
 2. Supress `unhandledRejection` notices on promises if user provides a callback (assumes the callback handles errors).
 3. Consistent behavior if they return a promise that is rejected with `null` / `undefined`
 4. Minor performance boost by only binding deferred.resolve/deferred.reject methods as needed

Closes #12