### PR TITLE
Support for functions that use plain callbacks added

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ printAfter(function () {
 });
 ```
 
+#### Calling a callback function
+
+If the wrapped function has a constant number of arguments, it can return its result through a callback function passed in through the last parameter.
+
+```js
+var runAsync = require('run-async');
+
+var sayHelloToJoe = function (func) {
+  var cb = function (err, returnValue) {
+    console.log(returnValue);
+  };
+  runAsync({fixedLength: true}, func, cb)('Joe');
+};
+
+// say hello in English
+sayHelloToJoe(function (name, cb) {
+  cb(null, 'Hello ' + name + '!');
+})
+```
+
 If your version of node support Promises natively (node >= 0.12), `runAsync` will return a promise. Example: `runAsync(func)(arg1, arg2).then(cb)`
 
 Licence

--- a/index.js
+++ b/index.js
@@ -9,24 +9,46 @@ var promiseResolver = require('promise-resolver');
  * example:
  * runAsync(wrappedFunction, callback)(...args);
  *
+ * @param   {Object} [opts]
+ * @param   {Object} [opts.fixedLength=false] Is true if the wrapped function can recieve
+ *                                            a specific number of arguments.
  * @param   {Function} func  Function to run
  * @param   {Function} cb    Callback function passed the `func` returned value
  * @return  {Function(arguments)} Arguments to pass to `func`. This function will in turn
  *                                return a Promise (Node >= 0.12) or call the callbacks.
  */
 
-module.exports = function (func, cb) {
+module.exports = function (/*[opts], func, cb*/) {
+  var opts, func, cb;
+  if (typeof arguments[0] === 'function') {
+    opts = {
+      fixedLength: false,
+    };
+    func = arguments[0];
+    cb = arguments[1];
+  } else {
+    opts = arguments[0];
+    func = arguments[1];
+    cb = arguments[2];
+  }
+
   return function () {
     var async = false;
     var deferred = promiseResolver.defer(cb);
 
     try {
+      var args = Array.prototype.slice.call(arguments);
+      if (opts.fixedLength && func.length === args.length + 1) {
+        args.push(deferred.cb);
+        async = true;
+      }
+
       var answer = func.apply({
         async: function () {
           async = true;
           return deferred.cb;
         }
-      }, Array.prototype.slice.call(arguments));
+      }, args);
 
       if (!async) {
         if (isPromise(answer)) {

--- a/test.js
+++ b/test.js
@@ -61,6 +61,20 @@ describe('runAsync', function () {
     })();
   });
 
+  it('handles nodeback', function (done) {
+    var fn = function (cb) {
+      setImmediate(function () {
+        cb(null, 'as promised!');
+      });
+    };
+
+    runAsync({fixedLength: true}, fn, function (err, val) {
+      assert.ifError(err);
+      assert.equal('as promised!', val);
+      done();
+    })();
+  });
+
   it('handles promises', function (done) {
     var fn = function () {
       return new Promise(function (resolve, reject) {


### PR DESCRIPTION
I would love to have the possibility to use `run-async` for functions that use a traditional callback as the last argument (not just `this.async()`).

However, it is not always possible to recognise a function that has a callback, so I added an optional first parameter that can confirm that the wrapped function has a constant number of input parameters. In that case if the wrapper function receives less parameters than what the target function expects, the last parameter should be a callback function.

I hope this change or a modification of it can go to the main package.