### PR TITLE
Extend custom context with async function

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,19 +11,21 @@ var Promise = require('pinkie-promise')
  *
  * @param   {Function} func  Function to run
  * @param   {Function} cb    Callback function passed the `func` returned value
+ * @param   {{}} ctx Custom func context
  * @return  {Function(arguments)} Arguments to pass to `func`. This function will in turn
  *                                return a Promise (Node >= 0.12) or call the callbacks.
  */
 
-var runAsync = module.exports = function (func, cb) {
+var runAsync = module.exports = function (func, cb, ctx) {
   cb = cb || function () {};
+  ctx = ctx || {};
 
   return function () {
     var async = false;
     var args = arguments;
 
     var promise = new Promise(function (resolve, reject) {
-      var answer = func.apply({
+      var answer = func.apply(Object.assign(ctx, {
         async: function () {
           async = true;
           return function (err, value) {
@@ -34,7 +36,7 @@ var runAsync = module.exports = function (func, cb) {
             }
           };
         }
-      }, Array.prototype.slice.call(args));
+      }), Array.prototype.slice.call(args));
 
       if (!async) {
         if (isPromise(answer)) {


### PR DESCRIPTION
Sometimes functions need to know about exact `this` context, we can pass it as additional param and extend with `async` function.