### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "flow-control",
     "async"
   ],
+  "files": ["index.js"],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Saves a kilobyte and a half from the package.