### PR TITLE
Bump minimum `node` version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - v0.10
   - v0.12
   - v4
   - v5

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var isPromise = require('is-promise');
-var Promise = require('pinkie-promise')
 
 /**
  * Return a function that will run a function asynchronously or synchronously

--- a/package.json
+++ b/package.json
@@ -6,18 +6,22 @@
   "scripts": {
     "test": "mocha -R spec"
   },
+  "engines": {
+    "node": ">=0.12.0"
+  },
   "repository": "SBoudrias/run-async",
   "keywords": [
     "flow",
     "flow-control",
     "async"
   ],
-  "files": ["index.js"],
+  "files": [
+    "index.js"
+  ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
   "dependencies": {
-    "is-promise": "^2.1.0",
-    "pinkie-promise": "^2.0.0"
+    "is-promise": "^2.1.0"
   },
   "devDependencies": {
     "mocha": "^3.1.2"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "flow-control",
     "async"
   ],
+  "files": ["index.js"],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,4 @@
 'use strict';
-var Promise = require('pinkie-promise');
 var assert = require('assert');
 var runAsync = require('./index');
 


### PR DESCRIPTION
Now requires `node` 0.12 or greater.  Drops `pinkie-promise`.