### PR TITLE
Add warning for run-async best practices and debug.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - v0.12
-  - v4
-  - v5
-  - v6
   - 10
+  - 12

--- a/index.js
+++ b/index.js
@@ -42,9 +42,14 @@ var runAsync = module.exports = function (func, cb) {
 
       var usingCallback = false;
       var callbackConflict = false;
+      var contextEnded = false;
 
       var answer = func.apply({
         async: function () {
+          if (contextEnded) {
+            console.warn('Run-async async() called outside a valid run-async context, callback will be ignored.');
+            return function() {};
+          }
           if (callbackConflict) {
             console.warn('Run-async wrapped function (async) returned a promise.\nCalls to async() callback can have unexpected results.');
           }
@@ -71,6 +76,7 @@ var runAsync = module.exports = function (func, cb) {
           wrappedResolve(answer);
         }
       }
+      contextEnded = true;
     });
 
     promise.then(cb.bind(null, null), cb);

--- a/test.js
+++ b/test.js
@@ -133,6 +133,34 @@ describe('runAsync', function () {
       done();
     })();
   });
+
+  it('ignores async callback outside original function context', function (done) {
+    var outsideContext = false;
+    var outsideContextCallback = async function () {
+      outsideContext = true;
+      this.async()(undefined, 'not as promised!');
+    };
+
+    var fn = async function () {
+      var self = this;
+      setTimeout(function () {
+        outsideContextCallback.call(self);
+      }, 100);
+      return new Promise(function (resolve, reject) {
+        setTimeout(function () {
+          outsideContext = false;
+          resolve('as promised!');
+        }, 500);
+      });
+    };
+
+    runAsync(fn, function (err, val) {
+      assert.equal(false, outsideContext);
+      assert.ifError(err);
+      assert.equal('as promised!', val);
+      done();
+    })();
+  });
 });
 
 describe('runAsync.cb', function () {

--- a/test.js
+++ b/test.js
@@ -121,6 +121,18 @@ describe('runAsync', function () {
       done();
     });
   });
+
+  it('handles async functions', function (done) {
+    var fn = async function () {
+      return 'as promised!';
+    };
+
+    runAsync(fn, function (err, val) {
+      assert.ifError(err);
+      assert.equal('as promised!', val);
+      done();
+    })();
+  });
 });
 
 describe('runAsync.cb', function () {


### PR DESCRIPTION
- If run-async sync callback is done, return a empty function.