### PR TITLE
use proxy for async binding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ printAfter(function () {
 });
 ```
 
+#### Custom done factory
+```js
+var runAsync = require('run-async');
+
+runAsync(function() {
+  var callback = this.customAsync();
+  callback(null, a + b);
+}, 'customAsync').(1, 2)
+```
+
+#### Passing context to async method
+```js
+var runAsync = require('run-async');
+
+runAsync(function() {
+  assert(this.isBound);
+  var callback = this.async();
+  callback(null, a + b);
+}).call({ isBound: true }, 1, 2)
+```
+
 ### runAsync.cb
 
 `runAsync.cb` supports all the function types that `runAsync` does and additionally a traditional **callback as the last argument** signature:
@@ -68,20 +89,6 @@ runAsync.cb(function(a, b, cb) {
 }, function(err, result) {
   console.log(result)
 })(1, 2)
-```
-
-### runAsync.proxy
-
-`runAsync.proxy` supports all the function types that `runAsync` does and additionally proxies a bound method with a custom done factory:
-
-```js
-var runAsync = require('run-async');
-
-runAsync.proxy(function() {
-  assert(this.isBound);
-  var callback = this.customAsync();
-  callback(null, a + b);
-}, 'customAsync').bind({ isBound: true })(1, 2)
 ```
 
 If your version of node support Promises natively (node >= 0.12), `runAsync` will return a promise. Example: `runAsync(func)(arg1, arg2).then(cb)`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ runAsync.cb(function(a, b, cb) {
 })(1, 2)
 ```
 
+### runAsync.proxy
+
+`runAsync.proxy` supports all the function types that `runAsync` does and additionally proxies a bound method with a custom done factory:
+
+```js
+var runAsync = require('run-async');
+
+runAsync.proxy(function() {
+  assert(this.isBound);
+  var callback = this.customAsync();
+  callback(null, a + b);
+}, 'customAsync').bind({ isBound: true })(1, 2)
+```
+
 If your version of node support Promises natively (node >= 0.12), `runAsync` will return a promise. Example: `runAsync(func)(arg1, arg2).then(cb)`
 
 Licence

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ var runAsync = require('run-async');
 runAsync(function() {
   var callback = this.customAsync();
   callback(null, a + b);
-}, 'customAsync').(1, 2)
+}, 'customAsync')(1, 2)
 ```
 
 #### Passing context to async method

--- a/test.js
+++ b/test.js
@@ -204,3 +204,50 @@ describe('runAsync.cb', function () {
     })('bar');
   });
 });
+
+describe('runAsync.proxy', function () {
+  it('handles custom done factory with not bound function', function (done) {
+    var fn = function () {
+      const cb = this.customAsync();
+      setImmediate(function () {
+        cb(null, 'value');
+      });
+    };
+
+    runAsync.proxy(fn, 'customAsync')().then(() => done());
+  });
+
+  it('handles custom done factory with bound function', function (done) {
+    var fn = function () {
+      const cb = this.async();
+      if (this.bar === 'bar') {
+        setImmediate(function () {
+          cb(null, 'value');
+        });
+      } else {
+        cb(new Error('not bount'));
+      }
+    };
+
+    runAsync.proxy(fn).bind({ bar: 'bar' })().then(() => done());
+  });
+
+  it('handles callback parameter', function (done) {
+    var fn = function () {
+      const cb = this.async();
+      if (this.bar === 'bar') {
+        setImmediate(function () {
+          cb(null, 'value');
+        });
+      } else {
+        cb(new Error('not bount'));
+      }
+    };
+
+    runAsync.proxy(fn, function (err, val) {
+      assert.ifError(err);
+      assert.equal('value', val);
+      done(err);
+    }).bind({ bar: 'bar' })();
+  });
+});

--- a/test.js
+++ b/test.js
@@ -173,7 +173,7 @@ describe('runAsync', function () {
     runAsync(fn, 'customAsync')().then(() => done());
   });
 
-  it('handles custom done factory with bound function', function (done) {
+  it('handles bound function', function (done) {
     var fn = function () {
       const cb = this.async();
       if (this.bar === 'bar') {
@@ -186,25 +186,6 @@ describe('runAsync', function () {
     };
 
     runAsync(fn).call({ bar: 'bar' }).then(() => done());
-  });
-
-  it('handles callback parameter', function (done) {
-    var fn = function () {
-      const cb = this.async();
-      if (this.bar === 'bar') {
-        setImmediate(function () {
-          cb(null, 'value');
-        });
-      } else {
-        cb(new Error('not bount'));
-      }
-    };
-
-    runAsync(fn, function (err, val) {
-      assert.ifError(err);
-      assert.equal('value', val);
-      done(err);
-    }).call({ bar: 'bar' });
   });
 });
 

--- a/test.js
+++ b/test.js
@@ -161,6 +161,51 @@ describe('runAsync', function () {
       done();
     })();
   });
+
+  it('handles custom done factory with not bound function', function (done) {
+    var fn = function () {
+      const cb = this.customAsync();
+      setImmediate(function () {
+        cb(null, 'value');
+      });
+    };
+
+    runAsync(fn, 'customAsync')().then(() => done());
+  });
+
+  it('handles custom done factory with bound function', function (done) {
+    var fn = function () {
+      const cb = this.async();
+      if (this.bar === 'bar') {
+        setImmediate(function () {
+          cb(null, 'value');
+        });
+      } else {
+        cb(new Error('not bount'));
+      }
+    };
+
+    runAsync(fn).call({ bar: 'bar' }).then(() => done());
+  });
+
+  it('handles callback parameter', function (done) {
+    var fn = function () {
+      const cb = this.async();
+      if (this.bar === 'bar') {
+        setImmediate(function () {
+          cb(null, 'value');
+        });
+      } else {
+        cb(new Error('not bount'));
+      }
+    };
+
+    runAsync(fn, function (err, val) {
+      assert.ifError(err);
+      assert.equal('value', val);
+      done(err);
+    }).call({ bar: 'bar' });
+  });
 });
 
 describe('runAsync.cb', function () {
@@ -202,52 +247,5 @@ describe('runAsync.cb', function () {
       assert.equal(result, 'foobar');
       done();
     })('bar');
-  });
-});
-
-describe('runAsync.proxy', function () {
-  it('handles custom done factory with not bound function', function (done) {
-    var fn = function () {
-      const cb = this.customAsync();
-      setImmediate(function () {
-        cb(null, 'value');
-      });
-    };
-
-    runAsync.proxy(fn, 'customAsync')().then(() => done());
-  });
-
-  it('handles custom done factory with bound function', function (done) {
-    var fn = function () {
-      const cb = this.async();
-      if (this.bar === 'bar') {
-        setImmediate(function () {
-          cb(null, 'value');
-        });
-      } else {
-        cb(new Error('not bount'));
-      }
-    };
-
-    runAsync.proxy(fn).bind({ bar: 'bar' })().then(() => done());
-  });
-
-  it('handles callback parameter', function (done) {
-    var fn = function () {
-      const cb = this.async();
-      if (this.bar === 'bar') {
-        setImmediate(function () {
-          cb(null, 'value');
-        });
-      } else {
-        cb(new Error('not bount'));
-      }
-    };
-
-    runAsync.proxy(fn, function (err, val) {
-      assert.ifError(err);
-      assert.equal('value', val);
-      done(err);
-    }).bind({ bar: 'bar' })();
   });
 });


### PR DESCRIPTION
To simplify, the idea is to remove the `this.async()` feature at `yeoman-generator` next major version.

I saw a lot of misuse like:
```
task() {
  const cb = this.async();
  someSyncFunction();
  cb();
}
```

For compatibility:
```
import runAsync from 'run-async';

class CustomGenerator extends Generator {
  get initializing() {
    return {
      asyncTask: runAsync(function() {
        const done = this.async();
        this.writeFile(...);
        methodWithCallback(done);
      }),
    }
  }
}
```