### PR TITLE
Move development tools to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "run-async",
       "version": "4.0.4",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "oxlint": "^1.2.0",
         "prettier": "^3.5.3"
       },
@@ -23,6 +23,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -35,6 +36,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -47,6 +49,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -59,6 +62,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -71,6 +75,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -83,6 +88,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -95,6 +101,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -107,6 +114,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -116,6 +124,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.2.0.tgz",
       "integrity": "sha512-zUtw37XW3fERrSJVVZfmHo35crJ7OS+Non9jk+kLtuhzEJYsbd1ORwGsnTVWy8oXEdNO/tXAUm+zVRoilEGelw==",
+      "dev": true,
       "bin": {
         "oxc_language_server": "bin/oxc_language_server",
         "oxlint": "bin/oxlint"
@@ -141,6 +150,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -157,54 +167,63 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.2.0.tgz",
       "integrity": "sha512-DsdZPp59sPPmuI6pR6MP1QepWWkpibFhVmRXa7ZOUobxxubUBg12SVCchAI1Iq8jejcAg9/XHXsRFpuny2LawQ==",
+      "dev": true,
       "optional": true
     },
     "@oxlint/darwin-x64": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.2.0.tgz",
       "integrity": "sha512-SN4lUlpGyFfGph+quUuGhEAyBMB87CgnFEK2bk3Lo96ehHcIhmzUH41nbsgi99k45+qEtD0ThIKAsbksOVn0uA==",
+      "dev": true,
       "optional": true
     },
     "@oxlint/linux-arm64-gnu": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.2.0.tgz",
       "integrity": "sha512-O03yN/Sas6/vyewiq8w9YN67yY8IofTpS28H2/f1a0Cb83Z7RbEzkWvsswq0erTHA0ctwJkzHfkRSRaBOmceBQ==",
+      "dev": true,
       "optional": true
     },
     "@oxlint/linux-arm64-musl": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.2.0.tgz",
       "integrity": "sha512-DO61+/vJkYRUEaVoajU2tLpVHBu3Fe8vhJ2mgxVNfOgQ7uIvHCB7wrnkHSPgABK9yROGenLWG9K6uHq3qiXj2g==",
+      "dev": true,
       "optional": true
     },
     "@oxlint/linux-x64-gnu": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.2.0.tgz",
       "integrity": "sha512-i2piovvEAKYsb23/NfiGug9Gqnf+5IoNgw7pDF/N7bPIFMJlzWACQHYi5dfIzFhG23FIdAnh+BHBDK9LKK5Jkw==",
+      "dev": true,
       "optional": true
     },
     "@oxlint/linux-x64-musl": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.2.0.tgz",
       "integrity": "sha512-r3AjtZ7BOArWoIjyjnT6Wj3jiv2anZbeL5jsj+sUMvd8m/t7sFb18ySRqS63d4yC6Ct3OZZVLFD4MADW658ghg==",
+      "dev": true,
       "optional": true
     },
     "@oxlint/win32-arm64": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.2.0.tgz",
       "integrity": "sha512-a0ZJE/QlJ1JdAc5FGytjwjBzq9oIbR7y9CwbVtrvwqOBaHzB7qssI93dGPZCRE4talL3dk18L6fthd6ijvLVxg==",
+      "dev": true,
       "optional": true
     },
     "@oxlint/win32-x64": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.2.0.tgz",
       "integrity": "sha512-OrWwyUCYGAnz5xDvVjCRFLp+XkQT56alXyx5kJDhDXKZzjajXwvFRFTvT3Hstu9I6bnCsqFjBcCbjQzmUBHOYw==",
+      "dev": true,
       "optional": true
     },
     "oxlint": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.2.0.tgz",
       "integrity": "sha512-zUtw37XW3fERrSJVVZfmHo35crJ7OS+Non9jk+kLtuhzEJYsbd1ORwGsnTVWy8oXEdNO/tXAUm+zVRoilEGelw==",
+      "dev": true,
       "requires": {
         "@oxlint/darwin-arm64": "1.2.0",
         "@oxlint/darwin-x64": "1.2.0",
@@ -219,7 +238,8 @@
     "prettier": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw=="
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "oxlint": "^1.2.0",
     "prettier": "^3.5.3"
   }


### PR DESCRIPTION
Follow up on https://x.com/boshen_c/status/1944301644478656663

This moves `oxlint` and `prettier` from `dependencies` to `devDependencies`. These are build-time tools that have no business being installed by downstream consumers

Currently every installation of run-async forces users to download ~22MB of linting tools they'll never use. With 21M+ weekly downloads and 1200+ dependents, this translates to unnecessary bandwidth and disk usage across the ecosystem

The change is completely safe since CI already runs `npm ci` which installs devDependencies, and the lint script uses `npx` which resolves from the full node_modules tree. End users get a cleaner, lighter installation while development workflows remain unchanged

Fixes #34 